### PR TITLE
Format code and add static checks CI

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,0 +1,15 @@
+name: Static Checks
+on: [push, pull_request]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip3 install gdtoolkit
+      - run: gdformat --diff .
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip3 install gdtoolkit
+      - run: gdlint .

--- a/addons/dockable_container/dockable_container.gd
+++ b/addons/dockable_container/dockable_container.gd
@@ -6,7 +6,9 @@ const DockablePanel = preload("dockable_panel.gd")
 const DragNDropPanel = preload("drag_n_drop_panel.gd")
 const Layout = preload("layout.gd")
 
+# gdlint: ignore=max-line-length
 export(int, "Left", "Center", "Right") var tab_align = TabContainer.ALIGN_CENTER setget set_tab_align, get_tab_align
+# gdlint: ignore=max-line-length
 export(bool) var use_hidden_tabs_for_min_size: bool setget set_use_hidden_tabs_for_min_size, get_use_hidden_tabs_for_min_size
 export(int) var rearrange_group = 0
 export(Resource) var layout = Layout.new() setget set_layout, get_layout
@@ -36,13 +38,13 @@ func _ready() -> void:
 	_split_container.name = "_split_container"
 	_split_container.mouse_filter = MOUSE_FILTER_PASS
 	_panel_container.add_child(_split_container)
-	
+
 	_drag_n_drop_panel.name = "_drag_n_drop_panel"
 	_drag_n_drop_panel.mouse_filter = MOUSE_FILTER_PASS
 	_drag_n_drop_panel.set_drag_forwarding(self)
 	_drag_n_drop_panel.visible = false
 	.add_child(_drag_n_drop_panel)
-	
+
 	if not _layout:
 		set_layout(null)
 	elif clone_layout_on_ready and not Engine.editor_hint:
@@ -52,7 +54,10 @@ func _ready() -> void:
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_SORT_CHILDREN:
 		_resort()
-	elif what == NOTIFICATION_DRAG_BEGIN and _can_handle_drag_data(get_viewport().gui_get_drag_data()):
+	elif (
+		what == NOTIFICATION_DRAG_BEGIN
+		and _can_handle_drag_data(get_viewport().gui_get_drag_data())
+	):
 		_drag_n_drop_panel.visible = true
 		set_process_input(true)
 	elif what == NOTIFICATION_DRAG_END:
@@ -93,29 +98,32 @@ func remove_child(node: Node) -> void:
 	_untrack_node(node)
 
 
-func can_drop_data_fw(position: Vector2, data, from_control) -> bool:
+func can_drop_data_fw(_position: Vector2, data, from_control) -> bool:
 	return from_control == _drag_n_drop_panel and _can_handle_drag_data(data)
 
 
-func drop_data_fw(position: Vector2, data, from_control) -> void:
+func drop_data_fw(_position: Vector2, data, from_control) -> void:
 	assert(from_control == _drag_n_drop_panel, "FIXME")
-	
+
 	var from_node: DockablePanel = get_node(data.from_path)
 	if _drag_panel == null or (from_node == _drag_panel and _drag_panel.get_child_count() == 1):
 		return
-	
+
 	var moved_tab = from_node.get_tab_control(data.tabc_element)
 	var moved_reference = moved_tab.reference_to
-	
+
 	var margin = _drag_n_drop_panel.get_hover_margin()
 	_layout.split_leaf_with_node(_drag_panel.leaf, moved_reference, margin)
 	_layout_dirty = true
-	
+
 	queue_sort()
 
 
 func set_control_as_current_tab(control: Control) -> void:
-	assert(control.get_parent_control() == self, "Trying to focus a control not managed by this container")
+	assert(
+		control.get_parent_control() == self,
+		"Trying to focus a control not managed by this container"
+	)
 	if is_control_hidden(control):
 		push_warning("Trying to focus a hidden control")
 		return
@@ -204,17 +212,21 @@ func get_tab_count() -> int:
 func _can_handle_drag_data(data):
 	if data is Dictionary and data.get("type") == "tabc_element":
 		var tabc = get_node_or_null(data.get("from_path"))
-		return (tabc
-				and tabc.has_method("get_tabs_rearrange_group")
-				and tabc.get_tabs_rearrange_group() == rearrange_group)
+		return (
+			tabc
+			and tabc.has_method("get_tabs_rearrange_group")
+			and tabc.get_tabs_rearrange_group() == rearrange_group
+		)
 	return false
 
 
 func _is_managed_node(node: Node) -> bool:
-	return (node != _panel_container
-			and node != _drag_n_drop_panel
-			and node is Control
-			and not node.is_set_as_toplevel())
+	return (
+		node != _panel_container
+		and node != _drag_n_drop_panel
+		and node is Control
+		and not node.is_set_as_toplevel()
+	)
 
 
 func _update_layout_with_children() -> void:
@@ -265,41 +277,43 @@ func _resort() -> void:
 		move_child(_panel_container, 0)
 	if _drag_n_drop_panel.get_position_in_parent() < get_child_count() - 1:
 		_drag_n_drop_panel.raise()
-	
+
 	if _layout_dirty:
 		_update_layout_with_children()
-	
+
 	var rect = Rect2(Vector2.ZERO, rect_size)
 	fit_child_in_rect(_panel_container, rect)
 	_panel_container.fit_child_in_rect(_split_container, rect)
-	
+
 	_current_panel_index = 1
 	_current_split_index = 0
-	
+
 	var children_list = []
 	_calculate_panel_and_split_list(children_list, _layout.root)
 	_fit_panel_and_split_list_to_rect(children_list, rect)
-	
+
 	_untrack_children_after(_panel_container, _current_panel_index)
 	_untrack_children_after(_split_container, _current_split_index)
 
 
 func _calculate_panel_and_split_list(result: Array, layout_node: Layout.LayoutNode):
-	"""
-	Calculate DockablePanel and SplitHandle minimum sizes, skipping empty branches.
-	
-	Returns a DockablePanel on non-empty leaves, a SplitHandle on non-empty
-	splits, `null` if the whole branch is empty and no space should be used.
-	
-	`result` will be filled with the non-empty nodes in this post-order tree traversal.
-	"""
+#	Calculate DockablePanel and SplitHandle minimum sizes, skipping empty branches.
+#
+#	Returns a DockablePanel on non-empty leaves, a SplitHandle on non-empty
+#	splits, `null` if the whole branch is empty and no space should be used.
+#
+#	`result` will be filled with the non-empty nodes in this post-order tree traversal.
+
 	if layout_node is Layout.LayoutPanel:
 		var nodes = []
 		for n in layout_node.names:
 			var node: Control = _children_names.get(n)
 			if node:
 				assert(node is Control, "FIXME: node is not a control %s" % node)
-				assert(node.get_parent_control() == self, "FIXME: node is not child of container %s" % node)
+				assert(
+					node.get_parent_control() == self,
+					"FIXME: node is not child of container %s" % node
+				)
 				if is_control_hidden(node):
 					node.visible = false
 				else:
@@ -334,11 +348,10 @@ func _calculate_panel_and_split_list(result: Array, layout_node: Layout.LayoutNo
 
 
 func _fit_panel_and_split_list_to_rect(panel_and_split_list: Array, rect: Rect2) -> void:
-	"""
-	Traverse list from back to front fitting controls where they belong.
-	
-	Be sure to call this with the result from `_calculate_split_minimum_sizes`.
-	"""
+#	Traverse list from back to front fitting controls where they belong.
+#
+#	Be sure to call this with the result from `_calculate_split_minimum_sizes`.
+
 	var control = panel_and_split_list.pop_back()
 	if control is DockablePanel:
 		_panel_container.fit_child_in_rect(control, rect)

--- a/addons/dockable_container/dockable_panel_reference_control.gd
+++ b/addons/dockable_container/dockable_panel_reference_control.gd
@@ -1,8 +1,7 @@
 tool
 extends Container
-"""
-Control that mimics its own visibility and rect into another Control.
-"""
+
+# Control that mimics its own visibility and rect into another Control.
 
 signal moved_in_parent(control)
 

--- a/addons/dockable_container/drag_n_drop_panel.gd
+++ b/addons/dockable_container/drag_n_drop_panel.gd
@@ -43,21 +43,21 @@ func get_hover_margin() -> int:
 
 func _find_hover_margin(point: Vector2):
 	var half_size = rect_size * 0.5
-	
+
 	var left = point.distance_squared_to(Vector2(0, half_size.y))
 	var lesser = left
 	var lesser_margin = MARGIN_LEFT
-	
+
 	var top = point.distance_squared_to(Vector2(half_size.x, 0))
 	if lesser > top:
 		lesser = top
 		lesser_margin = MARGIN_TOP
-	
+
 	var right = point.distance_squared_to(Vector2(rect_size.x, half_size.y))
 	if lesser > right:
 		lesser = right
 		lesser_margin = MARGIN_RIGHT
-	
+
 	var bottom = point.distance_squared_to(Vector2(half_size.x, rect_size.y))
 	if lesser > bottom:
 		#lesser = bottom  # unused result

--- a/addons/dockable_container/inspector_plugin/editor_inspector_plugin.gd
+++ b/addons/dockable_container/inspector_plugin/editor_inspector_plugin.gd
@@ -3,11 +3,14 @@ extends EditorInspectorPlugin
 const DockableContainer = preload("../dockable_container.gd")
 const LayoutEditorProperty = preload("layout_editor_property.gd")
 
+
 func can_handle(object: Object) -> bool:
 	return object is DockableContainer
 
 
-func parse_property(object: Object, type: int, path: String, hint: int, hint_text: String, usage: int) -> bool:
+func parse_property(
+	_object: Object, _type: int, path: String, _hint: int, _hint_text: String, _usage: int
+) -> bool:
 	if path == "layout":
 		var editor_property = LayoutEditorProperty.new()
 		add_property_editor("layout", editor_property)

--- a/addons/dockable_container/inspector_plugin/layout_editor_property.gd
+++ b/addons/dockable_container/inspector_plugin/layout_editor_property.gd
@@ -11,17 +11,17 @@ var _hidden_menu_list: PoolStringArray
 
 func _ready() -> void:
 	rect_min_size = Vector2(128, 256)
-	
+
 	_hidden_menu_button.text = "Visible nodes"
 	add_child(_hidden_menu_button)
 	_hidden_menu_popup = _hidden_menu_button.get_popup()
 	_hidden_menu_popup.hide_on_checkable_item_selection = false
 	_hidden_menu_popup.connect("about_to_show", self, "_on_hidden_menu_popup_about_to_show")
 	_hidden_menu_popup.connect("id_pressed", self, "_on_hidden_menu_popup_id_pressed")
-	
+
 	_container.clone_layout_on_ready = false
 	_container.rect_min_size = rect_min_size
-	
+
 	var original_container: DockableContainer = get_edited_object()
 	var value = original_container.get(get_edited_property())
 	_container.set(get_edited_property(), value)

--- a/addons/dockable_container/layout.gd
+++ b/addons/dockable_container/layout.gd
@@ -1,14 +1,13 @@
 tool
 extends Resource
-"""
-Layout Resource definition, holding the root LayoutNode and hidden tabs.
 
-LayoutSplit are binary trees with nested LayoutSplit subtrees and LayoutPanel
-leaves. Both of them inherit from LayoutNode to help with type annotation and
-define common funcionality.
-
-Hidden tabs are marked in the `hidden_tabs` Dictionary by name.
-"""
+# Layout Resource definition, holding the root LayoutNode and hidden tabs.
+#
+# LayoutSplit are binary trees with nested LayoutSplit subtrees and LayoutPanel
+# leaves. Both of them inherit from LayoutNode to help with type annotation and
+# define common funcionality.
+#
+# Hidden tabs are marked in the `hidden_tabs` Dictionary by name.
 
 const LayoutNode = preload("layout_node.gd")
 const LayoutPanel = preload("layout_panel.gd")
@@ -68,13 +67,12 @@ func get_names() -> PoolStringArray:
 
 
 func update_nodes(names: PoolStringArray) -> void:
-	"""
-	Add missing nodes on first leaf and remove nodes outside indices from leaves.
-	
-	_leaf_by_node_name = {
-		(string keys) = respective Leaf that holds the node name,
-	}
-	"""
+#	Add missing nodes on first leaf and remove nodes outside indices from leaves.
+#
+#	_leaf_by_node_name = {
+#		(string keys) = respective Leaf that holds the node name,
+#	}
+
 	_leaf_by_node_name.clear()
 	_first_leaf = null
 	var empty_leaves = []
@@ -99,7 +97,7 @@ func move_node_to_leaf(node: Node, leaf: LayoutPanel, relative_position: int) ->
 	previous_leaf.remove_node(node)
 	if previous_leaf.empty():
 		_remove_leaf(previous_leaf)
-	
+
 	leaf.insert_node(relative_position, node)
 	_leaf_by_node_name[node_name] = leaf
 	_on_root_changed()
@@ -130,7 +128,7 @@ func split_leaf_with_node(leaf, node: Node, margin: int) -> void:
 			root_branch.first = new_branch
 		else:
 			root_branch.second = new_branch
-	
+
 	move_node_to_leaf(node, new_leaf, 0)
 
 
@@ -215,7 +213,11 @@ func _remove_leaf(leaf: LayoutPanel) -> void:
 		return
 	var collapsed_branch = leaf.parent
 	assert(collapsed_branch is LayoutSplit, "FIXME: leaf is not a child of branch")
-	var kept_branch = collapsed_branch.first if leaf == collapsed_branch.second else collapsed_branch.second
+	var kept_branch = (
+		collapsed_branch.first
+		if leaf == collapsed_branch.second
+		else collapsed_branch.second
+	)
 	var root_branch = collapsed_branch.parent
 	if collapsed_branch == _root:
 		set_root(kept_branch, true)
@@ -236,6 +238,12 @@ func _print_tree_step(tree_or_leaf, level, idx) -> void:
 	if tree_or_leaf is LayoutPanel:
 		print(" |".repeat(level), "- (%d) = " % idx, tree_or_leaf.names)
 	else:
-		print(" |".repeat(level), "-+ (%d) = " % idx, tree_or_leaf.direction, " ", tree_or_leaf.percent)
+		print(
+			" |".repeat(level),
+			"-+ (%d) = " % idx,
+			tree_or_leaf.direction,
+			" ",
+			tree_or_leaf.percent
+		)
 		_print_tree_step(tree_or_leaf.first, level + 1, 1)
 		_print_tree_step(tree_or_leaf.second, level + 1, 2)

--- a/addons/dockable_container/layout_node.gd
+++ b/addons/dockable_container/layout_node.gd
@@ -1,6 +1,6 @@
 tool
 extends Resource
-"""Base class for Layout tree nodes"""
+# Base class for Layout tree nodes
 
 var parent = null
 
@@ -13,22 +13,21 @@ func emit_tree_changed() -> void:
 
 
 func clone():
-	"""
-	Returns a deep copy of the layout.
-	
-	Use this instead of `Resource.duplicate(true)` to ensure objects have the
-	right script and parenting is correctly set for each node.
-	"""
+#	Returns a deep copy of the layout.
+#
+#	Use this instead of `Resource.duplicate(true)` to ensure objects have the
+#	right script and parenting is correctly set for each node.
+
 	assert("FIXME: implement on child")
 
 
 func empty() -> bool:
-	"""Returns whether there are any nodes"""
+	# Returns whether there are any nodes
 	assert("FIXME: implement on child")
 	return true
 
 
 func get_names() -> PoolStringArray:
-	"""Returns all tab names in this node"""
+	# Returns all tab names in this node
 	assert("FIXME: implement on child")
 	return PoolStringArray()

--- a/addons/dockable_container/layout_panel.gd
+++ b/addons/dockable_container/layout_panel.gd
@@ -1,6 +1,6 @@
 tool
 extends "layout_node.gd"
-"""Layout leaf nodes, defining tabs"""
+# Layout leaf nodes, defining tabs
 
 export(PoolStringArray) var names: PoolStringArray setget set_names, get_names
 export(int) var current_tab: int setget set_current_tab, get_current_tab

--- a/addons/dockable_container/layout_split.gd
+++ b/addons/dockable_container/layout_split.gd
@@ -1,6 +1,6 @@
 tool
 extends "layout_node.gd"
-"""Layout binary tree nodes, defining subtrees and leaf panels"""
+# Layout binary tree nodes, defining subtrees and leaf panels
 
 enum Direction {
 	HORIZONTAL,

--- a/addons/dockable_container/plugin.gd
+++ b/addons/dockable_container/plugin.gd
@@ -6,6 +6,7 @@ const LayoutInspectorPlugin = preload("inspector_plugin/editor_inspector_plugin.
 
 var _layout_inspector_plugin = LayoutInspectorPlugin.new()
 
+
 func _enter_tree() -> void:
 	add_custom_type("DockableContainer", "Container", DockableContainer, null)
 	add_inspector_plugin(_layout_inspector_plugin)

--- a/addons/dockable_container/samples/TestScene.gd
+++ b/addons/dockable_container/samples/TestScene.gd
@@ -11,7 +11,7 @@ func _ready() -> void:
 	if not OS.is_userfs_persistent():
 		$HBoxContainer/SaveLayoutButton.visible = false
 		$HBoxContainer/LoadLayoutButton.visible = false
-	
+
 	var tabs = _container.get_tabs()
 	for i in tabs.size():
 		var checkbox = CheckBox.new()
@@ -23,11 +23,15 @@ func _ready() -> void:
 
 func _on_add_pressed() -> void:
 	var control = _clone_control.duplicate()
-	control.get_node("Buttons/Rename").connect("pressed", self, "_on_control_rename_button_pressed", [control])
-	control.get_node("Buttons/Remove").connect("pressed", self, "_on_control_remove_button_pressed", [control])
+	control.get_node("Buttons/Rename").connect(
+		"pressed", self, "_on_control_rename_button_pressed", [control]
+	)
+	control.get_node("Buttons/Remove").connect(
+		"pressed", self, "_on_control_remove_button_pressed", [control]
+	)
 	control.color = Color(randf(), randf(), randf())
 	control.name = "Control0"
-	
+
 	_container.add_child(control, true)
 	yield(_container, "sort_children")
 	_container.set_control_as_current_tab(control)

--- a/addons/dockable_container/split_handle.gd
+++ b/addons/dockable_container/split_handle.gd
@@ -28,8 +28,8 @@ func _draw() -> void:
 	var autohide = bool(get_constant("autohide", theme_class))
 	if not icon or (autohide and not _mouse_hovering):
 		return
-	
-	draw_texture(icon, (rect_size - icon.get_size()) * 0.5 )
+
+	draw_texture(icon, (rect_size - icon.get_size()) * 0.5)
 
 
 func _gui_input(event: InputEvent) -> void:
@@ -40,9 +40,15 @@ func _gui_input(event: InputEvent) -> void:
 	elif _dragging and event is InputEventMouseMotion:
 		var mouse_in_parent = get_parent_control().get_local_mouse_position()
 		if layout_split.is_horizontal():
-			layout_split.percent = (mouse_in_parent.x - _parent_rect.position.x) / _parent_rect.size.x
+			layout_split.percent = (
+				(mouse_in_parent.x - _parent_rect.position.x)
+				/ _parent_rect.size.x
+			)
 		else:
-			layout_split.percent = (mouse_in_parent.y - _parent_rect.position.y) / _parent_rect.size.y
+			layout_split.percent = (
+				(mouse_in_parent.y - _parent_rect.position.y)
+				/ _parent_rect.size.y
+			)
 
 
 func _notification(what: int) -> void:
@@ -65,9 +71,15 @@ func get_layout_minimum_size() -> Vector2:
 		return Vector2.ZERO
 	var separation = get_constant("separation", SPLIT_THEME_CLASS[layout_split.direction])
 	if layout_split.is_horizontal():
-		return Vector2(first_minimum_size.x + separation + second_minimum_size.x, max(first_minimum_size.y, second_minimum_size.y))
+		return Vector2(
+			first_minimum_size.x + separation + second_minimum_size.x,
+			max(first_minimum_size.y, second_minimum_size.y)
+		)
 	else:
-		return Vector2(max(first_minimum_size.x, second_minimum_size.x), first_minimum_size.y + separation + second_minimum_size.y)
+		return Vector2(
+			max(first_minimum_size.x, second_minimum_size.x),
+			first_minimum_size.y + separation + second_minimum_size.y
+		)
 
 
 func set_split_cursor(value: bool) -> void:
@@ -85,9 +97,13 @@ func get_split_rects(rect: Rect2) -> Dictionary:
 	var percent = layout_split.percent
 	if layout_split.is_horizontal():
 		var first_width = max((size.x - separation) * percent, first_minimum_size.x)
-		var split_offset = clamp(size.x * percent - separation * 0.5, first_minimum_size.x, size.x - second_minimum_size.x - separation)
+		var split_offset = clamp(
+			size.x * percent - separation * 0.5,
+			first_minimum_size.x,
+			size.x - second_minimum_size.x - separation
+		)
 		var second_width = size.x - split_offset - separation
-		
+
 		return {
 			"first": Rect2(origin.x, origin.y, split_offset, size.y),
 			"self": Rect2(origin.x + split_offset, origin.y, separation, size.y),
@@ -95,9 +111,13 @@ func get_split_rects(rect: Rect2) -> Dictionary:
 		}
 	else:
 		var first_height = max((size.y - separation) * percent, first_minimum_size.y)
-		var split_offset = clamp(size.y * percent - separation * 0.5, first_minimum_size.y, size.y - second_minimum_size.y - separation)
+		var split_offset = clamp(
+			size.y * percent - separation * 0.5,
+			first_minimum_size.y,
+			size.y - second_minimum_size.y - separation
+		)
 		var second_height = size.y - split_offset - separation
-		
+
 		return {
 			"first": Rect2(origin.x, origin.y, size.x, split_offset),
 			"self": Rect2(origin.x, origin.y + split_offset, size.x, separation),

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,6 @@ config_version=4
 
 _global_script_classes=[  ]
 _global_script_class_icons={
-
 }
 
 [application]


### PR DESCRIPTION
Run commands `gdformat .` and `gdlint .` from the [godot-gdscript-toolkit](https://github.com/Scony/godot-gdscript-toolkit) to improve the code quality and ensure it follows [GDScript's style guide and best practices](https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_styleguide.html). Functionality-wise, nothing should change. Along with the changes, multi-line comments were changed from """ to # to make it more clear that they are comments and not multi-line strings.

This PR also adds a GitHub Actions workflow that runs these two commands for every commit in this repository. The workflow won't have any effect on the code by itself, it only serves to output errors from the formatter and/or the linter, if any.