### PR TITLE
Fix _reference_to control with dynamic _get_minimum_size method

### DIFF
--- a/addons/dockable_container/dockable_panel_reference_control.gd
+++ b/addons/dockable_container/dockable_panel_reference_control.gd
@@ -26,7 +26,9 @@ func set_reference_to(control: Control) -> void:
 	if _reference_to != control:
 		if _reference_to:
 			_reference_to.disconnect("renamed", self, "_on_reference_to_renamed")
+			_reference_to.disconnect("minimum_size_changed", self, "minimum_size_changed")
 		_reference_to = control
+		_reference_to.connect("minimum_size_changed", self, "minimum_size_changed")
 		minimum_size_changed()
 		if not _reference_to:
 			return

--- a/addons/dockable_container/dockable_panel_reference_control.gd
+++ b/addons/dockable_container/dockable_panel_reference_control.gd
@@ -28,11 +28,11 @@ func set_reference_to(control: Control) -> void:
 			_reference_to.disconnect("renamed", self, "_on_reference_to_renamed")
 			_reference_to.disconnect("minimum_size_changed", self, "minimum_size_changed")
 		_reference_to = control
-		_reference_to.connect("minimum_size_changed", self, "minimum_size_changed")
 		minimum_size_changed()
 		if not _reference_to:
 			return
 		_reference_to.connect("renamed", self, "_on_reference_to_renamed")
+		_reference_to.connect("minimum_size_changed", self, "minimum_size_changed")
 		_reference_to.visible = visible
 
 


### PR DESCRIPTION
Working on improving the timeline in Pixelorama, I used the get_minimum_size method
![image](https://user-images.githubusercontent.com/65431647/196558382-b2144b98-05b7-49eb-a33a-e774292c879c.png)

Which causes this when the minimum size changes:
https://user-images.githubusercontent.com/65431647/196558364-633eae73-17ed-442f-b444-7235332a4f35.mp4

Fixed:
https://user-images.githubusercontent.com/65431647/196559163-2a40da70-b87a-4399-be02-875f016502cc.mp4

