### PR TITLE
Upgrade to Godot 4.1, connect active_tab_rearranged signal

### DIFF
--- a/addons/dockable_container/dockable_panel.gd
+++ b/addons/dockable_container/dockable_panel.gd
@@ -17,11 +17,13 @@ func _ready() -> void:
 
 
 func _enter_tree() -> void:
+	active_tab_rearranged.connect(_on_tab_changed)
 	tab_selected.connect(_on_tab_selected)
 	tab_changed.connect(_on_tab_changed)
 
 
 func _exit_tree() -> void:
+	active_tab_rearranged.disconnect(_on_tab_changed)
 	tab_selected.disconnect(_on_tab_selected)
 	tab_changed.disconnect(_on_tab_changed)
 

--- a/addons/dockable_container/inspector_plugin/editor_inspector_plugin.gd
+++ b/addons/dockable_container/inspector_plugin/editor_inspector_plugin.gd
@@ -13,7 +13,7 @@ func _parse_property(
 	name: String,
 	_hint: PropertyHint,
 	_hint_text: String,
-	_usage: PropertyUsageFlags,
+	_usage: int,
 	_wide: bool
 ) -> bool:
 	if name == "layout":

--- a/project.godot
+++ b/project.godot
@@ -19,7 +19,7 @@ Layout information is stored in Resource objects, so they can be saved/loaded fr
 
 This plugin also offers a replica of the Container layout to be edited directly in the inspector."
 run/main_scene="res://addons/dockable_container/samples/TestScene.tscn"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 config/icon="res://icon.svg"
 
 [debug]


### PR DESCRIPTION
Now that Godot 4.1 is out, the `active_tab_rearranged` signal can be used to re-arrange tabs in the same panel, as promised in #21. This PR also changes `parse_property()`'s usage parameter to an int in editor_inspector_plugin.gd, because using `PropertyUsageFlags` as a type hint results in an error in 4.1.

Note that this makes the addon not open on 4.0 anymore, unless the user manually removes the new signals.