### PR TITLE
Make tabs able to be dragged and dropped into panels in Godot 4.2

### DIFF
--- a/addons/dockable_container/dockable_container.gd
+++ b/addons/dockable_container/dockable_container.gd
@@ -128,11 +128,13 @@ func _can_drop_data(_position: Vector2, data) -> bool:
 
 
 func _drop_data(_position: Vector2, data) -> void:
-	var from_node := get_node(data.from_path) as DockablePanel
+	var from_node := get_node(data.from_path)
+	if from_node is TabBar:
+		from_node = from_node.get_parent()
 	if from_node == _drag_panel and _drag_panel.get_child_count() == 1:
 		return
-
-	var moved_tab := from_node.get_tab_control(data.tabc_element)
+	var tab_index = data.tabc_element if data.has("tabc_element") else data.tab_index
+	var moved_tab = from_node.get_tab_control(tab_index)
 	if moved_tab is DockableReferenceControl:
 		moved_tab = moved_tab.reference_to
 	if not _is_managed_node(moved_tab):
@@ -234,7 +236,7 @@ func get_tab_count() -> int:
 
 
 func _can_handle_drag_data(data) -> bool:
-	if data is Dictionary and data.get("type") == "tabc_element":
+	if data is Dictionary and data.get("type") in ["tab_container_tab", "tabc_element"]:
 		var tabc := get_node_or_null(data.get("from_path"))
 		return (
 			tabc

--- a/project.godot
+++ b/project.godot
@@ -19,7 +19,7 @@ Layout information is stored in Resource objects, so they can be saved/loaded fr
 
 This plugin also offers a replica of the Container layout to be edited directly in the inspector."
 run/main_scene="res://addons/dockable_container/samples/TestScene.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.svg"
 
 [debug]


### PR DESCRIPTION
Seems like Godot 4.2 changes a few things internally when it comes to TabContainers and as a result tabs could not be dragged and dropped into panels, only in other TabBars. This happened most likely due to this PR https://github.com/godotengine/godot/pull/83637

I also added statements with the help of `Engine.get_version_info()` to preserve compatibility with Godot 4.1.

Because Godot 4.2 is still in beta, perhaps we should wait until the stable version is out before merging this PR, in case they change stuff again.