### PR TITLE
Use WeakRef in layout node parent to avoid cyclic strong references

### DIFF
--- a/addons/dockable_container/layout_node.gd
+++ b/addons/dockable_container/layout_node.gd
@@ -3,7 +3,12 @@ class_name DockableLayoutNode
 extends Resource
 ## Base class for DockableLayout tree nodes
 
-var parent: DockableLayoutSplit = null
+var parent: DockableLayoutSplit:
+	get:
+		return _parent_ref.get_ref() if _parent_ref else null
+	set(value):
+		_parent_ref = weakref(value)
+var _parent_ref: WeakRef
 
 
 func emit_tree_changed() -> void:

--- a/addons/dockable_container/layout_node.gd
+++ b/addons/dockable_container/layout_node.gd
@@ -5,10 +5,11 @@ extends Resource
 
 var parent: DockableLayoutSplit:
 	get:
-		return _parent_ref.get_ref() if _parent_ref else null
+		return _parent_ref.get_ref()
 	set(value):
 		_parent_ref = weakref(value)
-var _parent_ref: WeakRef
+
+var _parent_ref := WeakRef.new()
 
 
 func emit_tree_changed() -> void:


### PR DESCRIPTION
Fixes #12.