### PR TITLE
Add an option to always have the tabs visible, if a panel has more than one tab

### DIFF
--- a/addons/dockable_container/dockable_container.gd
+++ b/addons/dockable_container/dockable_container.gd
@@ -26,15 +26,19 @@ const DragNDropPanel := preload("drag_n_drop_panel.gd")
 	get:
 		return _tabs_visible
 	set(value):
-		set_tabs_visible(value)
-## Always ensure that tabs are visible if a panel has more than one tab.
-## Only takes effect is [member tabs_visible] is [code]false[/code].
-@export var tabs_visible_if_more_than_one := false:
+		_tabs_visible = value
+		for panel in _panel_container.get_children():
+			panel.tabs_hidden = not _tabs_visible
+## If [code]true[/code] and a panel only has one tab, it keeps that tab hidden even if
+## [member tabs_visible] is [code]true[/code].
+## Only takes effect is [member tabs_visible] is [code]true[/code].
+@export var hide_single_tab := false:
 	get:
-		return _tabs_visible_if_more_than_one
+		return _hide_single_tab
 	set(value):
-		_tabs_visible_if_more_than_one = value
-		set_tabs_visible(_tabs_visible)
+		_hide_single_tab = value
+		for panel in _panel_container.get_children():
+			panel.hide_single_tab = _hide_single_tab
 @export var rearrange_group := 0
 @export var layout := DockableLayout.new():
 	get:
@@ -54,7 +58,7 @@ var _drag_panel: DockablePanel
 var _tab_align := TabBar.ALIGNMENT_CENTER
 var _tabs_visible := true
 var _use_hidden_tabs_for_min_size := false
-var _tabs_visible_if_more_than_one := false
+var _hide_single_tab := false
 var _current_panel_index := 0
 var _current_split_index := 0
 var _children_names := {}
@@ -193,20 +197,6 @@ func set_layout(value: DockableLayout) -> void:
 	queue_sort()
 
 
-func set_tabs_visible(value: bool) -> void:
-	_tabs_visible = value
-	for i in range(1, _panel_container.get_child_count()):
-		var panel := _panel_container.get_child(i) as DockablePanel
-		if _tabs_visible_if_more_than_one and panel.get_tab_count() > 1:
-			panel.tabs_visible = true
-		else:
-			panel.tabs_visible = value
-
-
-func get_tabs_visible() -> bool:
-	return _tabs_visible
-
-
 func set_use_hidden_tabs_for_min_size(value: bool) -> void:
 	_use_hidden_tabs_for_min_size = value
 	for i in range(1, _panel_container.get_child_count()):
@@ -330,8 +320,6 @@ func _resort() -> void:
 
 	_untrack_children_after(_panel_container, _current_panel_index)
 	_untrack_children_after(_split_container, _current_split_index)
-	if not tabs_visible and tabs_visible_if_more_than_one:
-		set_tabs_visible(_tabs_visible)
 
 
 ## Calculate DockablePanel and SplitHandle minimum sizes, skipping empty
@@ -407,7 +395,8 @@ func _get_panel(idx: int) -> DockablePanel:
 		return _panel_container.get_child(idx)
 	var panel := DockablePanel.new()
 	panel.tab_alignment = _tab_align
-	panel.tabs_visible = _tabs_visible
+	panel.tabs_hidden = not _tabs_visible
+	panel.hide_single_tab = _hide_single_tab
 	panel.use_hidden_tabs_for_min_size = _use_hidden_tabs_for_min_size
 	panel.set_tabs_rearrange_group(maxi(0, rearrange_group))
 	_panel_container.add_child(panel)

--- a/addons/dockable_container/dockable_container.gd
+++ b/addons/dockable_container/dockable_container.gd
@@ -27,8 +27,9 @@ const DragNDropPanel := preload("drag_n_drop_panel.gd")
 		return _tabs_visible
 	set(value):
 		_tabs_visible = value
-		for panel in _panel_container.get_children():
-			panel.tabs_hidden = not _tabs_visible
+		for i in range(1, _panel_container.get_child_count()):
+			var panel := _panel_container.get_child(i) as DockablePanel
+			panel.show_tabs = _tabs_visible
 ## If [code]true[/code] and a panel only has one tab, it keeps that tab hidden even if
 ## [member tabs_visible] is [code]true[/code].
 ## Only takes effect is [member tabs_visible] is [code]true[/code].
@@ -37,7 +38,8 @@ const DragNDropPanel := preload("drag_n_drop_panel.gd")
 		return _hide_single_tab
 	set(value):
 		_hide_single_tab = value
-		for panel in _panel_container.get_children():
+		for i in range(1, _panel_container.get_child_count()):
+			var panel := _panel_container.get_child(i) as DockablePanel
 			panel.hide_single_tab = _hide_single_tab
 @export var rearrange_group := 0
 @export var layout := DockableLayout.new():
@@ -395,7 +397,7 @@ func _get_panel(idx: int) -> DockablePanel:
 		return _panel_container.get_child(idx)
 	var panel := DockablePanel.new()
 	panel.tab_alignment = _tab_align
-	panel.tabs_hidden = not _tabs_visible
+	panel.show_tabs = _tabs_visible
 	panel.hide_single_tab = _hide_single_tab
 	panel.use_hidden_tabs_for_min_size = _use_hidden_tabs_for_min_size
 	panel.set_tabs_rearrange_group(maxi(0, rearrange_group))

--- a/addons/dockable_container/dockable_panel.gd
+++ b/addons/dockable_container/dockable_panel.gd
@@ -8,8 +8,22 @@ var leaf: DockableLayoutPanel:
 		return get_leaf()
 	set(value):
 		set_leaf(value)
+var tabs_hidden := false:
+	get:
+		return _tabs_hidden
+	set(value):
+		_tabs_hidden = value
+		_handle_tab_visibility()
+var hide_single_tab := false:
+	get:
+		return _hide_single_tab
+	set(value):
+		_hide_single_tab = value
+		_handle_tab_visibility()
 
 var _leaf: DockableLayoutPanel
+var _tabs_hidden := false
+var _hide_single_tab := false
 
 
 func _ready() -> void:
@@ -48,6 +62,7 @@ func track_nodes(nodes: Array[Control], new_leaf: DockableLayoutPanel) -> void:
 		ref_control.reference_to = nodes[i]
 		set_tab_title(i, nodes[i].name)
 	set_leaf(new_leaf)
+	_handle_tab_visibility()
 
 
 func get_child_rect() -> Rect2:
@@ -84,3 +99,10 @@ func _on_tab_changed(tab: int) -> void:
 	var name_index_in_leaf := _leaf.find_name(tab_name)
 	if name_index_in_leaf != tab:  # NOTE: this handles added tabs (index == -1)
 		tab_layout_changed.emit(tab)
+
+
+func _handle_tab_visibility() -> void:
+	if _hide_single_tab and get_tab_count() == 1:
+		tabs_visible = false
+	else:
+		tabs_visible = not _tabs_hidden

--- a/addons/dockable_container/dockable_panel.gd
+++ b/addons/dockable_container/dockable_panel.gd
@@ -8,11 +8,11 @@ var leaf: DockableLayoutPanel:
 		return get_leaf()
 	set(value):
 		set_leaf(value)
-var tabs_hidden := false:
+var show_tabs := true:
 	get:
-		return _tabs_hidden
+		return _show_tabs
 	set(value):
-		_tabs_hidden = value
+		_show_tabs = value
 		_handle_tab_visibility()
 var hide_single_tab := false:
 	get:
@@ -22,7 +22,7 @@ var hide_single_tab := false:
 		_handle_tab_visibility()
 
 var _leaf: DockableLayoutPanel
-var _tabs_hidden := false
+var _show_tabs := true
 var _hide_single_tab := false
 
 
@@ -105,4 +105,4 @@ func _handle_tab_visibility() -> void:
 	if _hide_single_tab and get_tab_count() == 1:
 		tabs_visible = false
 	else:
-		tabs_visible = not _tabs_hidden
+		tabs_visible = _show_tabs


### PR DESCRIPTION
This new option ensures than a dockable panel will have its tabs visible, even when `tabs_visible = false`, when it has more than one tab.

![image](https://github.com/gilzoide/godot-dockable-container/assets/35376950/7213db51-2869-4a34-8aaf-d4f752fb0282)

Above is a panel with just one tab, and below is a panel with two tabs. This happens when `tabs_visible = false` and `tabs_visible_if_more_than_one = true`.

This is something we did in [Pixelorama 0.x](https://github.com/Orama-Interactive/Pixelorama/blob/0.x/addons/dockable_container/dockable_container.gd#L187), because we wanted to avoid tabs being visible when unnecessary, but I never ported the change here so I thought I might as well do that.

This PR also removes `set_tab_alignment()` and `get_tab_align()`, as they were unused because the `tab_alignment` variable already has a getter and setter.

One thing I'm not too sure about is the variable name `tabs_visible_if_more_than_one`. I feel like this might be a bit too long (although `use_hidden_tabs_for_min_size` is also about the same length), but I'm not sure how to make it shorter while also ensuring that its purpose is clear.

And I'm also not sure about calling `set_tabs_visible()` in `_resort()`. There may be a more optimal way to do this, but without this, tab visibility isn't being updated when a panel gets added/removed/hidden.