### PR TITLE
add tab title rename logic

### DIFF
--- a/addons/dockable_container/dockable_container.gd
+++ b/addons/dockable_container/dockable_container.gd
@@ -446,3 +446,8 @@ func _on_child_renamed(child: Node) -> void:
 	_children_names[child] = child.name
 	_children_names[child.name] = child
 	_layout.rename_node(old_name, child.name)
+
+func set_tab_title_for_node_named(node_name: String, tab_title: String):
+	for panel in _panel_container.get_children():
+		if panel.has_method("setup_tab_name_for_node_named"):
+			panel.setup_tab_name_for_node_named(node_name, tab_title)

--- a/addons/dockable_container/dockable_panel.gd
+++ b/addons/dockable_container/dockable_panel.gd
@@ -24,6 +24,7 @@ var hide_single_tab := false:
 var _leaf: DockableLayoutPanel
 var _show_tabs := true
 var _hide_single_tab := false
+var _tabs_children_names = {}
 
 
 func _ready() -> void:
@@ -43,6 +44,7 @@ func _exit_tree() -> void:
 
 
 func track_nodes(nodes: Array[Control], new_leaf: DockableLayoutPanel) -> void:
+	_tabs_children_names = {}
 	_leaf = null  # avoid using previous leaf in tab_changed signals
 	var min_size := mini(nodes.size(), get_child_count())
 	# remove spare children
@@ -61,8 +63,15 @@ func track_nodes(nodes: Array[Control], new_leaf: DockableLayoutPanel) -> void:
 		var ref_control := get_child(i) as DockableReferenceControl
 		ref_control.reference_to = nodes[i]
 		set_tab_title(i, nodes[i].name)
+		_tabs_children_names[nodes[i].name] = i
 	set_leaf(new_leaf)
 	_handle_tab_visibility()
+
+
+func setup_tab_name_for_node_named(node_name: String, tab_title: String):
+	if !_tabs_children_names.has(node_name):
+		return
+	set_tab_title(_tabs_children_names[node_name], tab_title)
 
 
 func get_child_rect() -> Rect2:


### PR DESCRIPTION
I added tab title rename logic
It allows you to rename tabs without affecting tab node paths as it is now
To be honest, this solution looks bad. If you have an advice on haw to improve it I would be happy to make an update but now it is something at least