### PR TITLE
Implement floating windows

### DIFF
--- a/addons/dockable_container/dockable_container.gd
+++ b/addons/dockable_container/dockable_container.gd
@@ -2,9 +2,6 @@
 class_name DockableContainer
 extends Container
 
-signal window_created
-signal window_closed
-
 const SplitHandle := preload("split_handle.gd")
 const DockablePanel := preload("dockable_panel.gd")
 const DragNDropPanel := preload("drag_n_drop_panel.gd")
@@ -176,7 +173,7 @@ func _add_floating_options(tab_container: TabContainer) -> void:
 	tab_container.set_popup(options)
 
 
-## required when converting a window back to panel
+## Required when converting a window back to panel.
 func _refresh_tabs_visible() -> void:
 	if tabs_visible:
 		tabs_visible = false
@@ -192,6 +189,7 @@ func _toggle_floating(_id: int, tab_container: TabContainer) -> void:
 		_convert_to_window(node)
 
 
+## Converts a panel to floating window.
 func _convert_to_window(content: Control) -> void:
 	var old_owner := content.owner
 	var data := {}
@@ -205,6 +203,7 @@ func _convert_to_window(content: Control) -> void:
 	window.data_changed.connect(layout.save_window_properties)
 
 
+## Converts a floating window into a panel.
 func _convert_to_panel(window: FloatingWindow, old_owner: Node) -> void:
 	var content := window.window_content
 	window.remove_child(content)
@@ -250,12 +249,12 @@ func set_layout(value: DockableLayout) -> void:
 	_layout.changed.connect(queue_sort)
 	for window in _windows_container.get_children():
 		if not window.name in _layout.windows and window is FloatingWindow:
-			window.prevent_data_erasure = true  # We don't want to delete data
-			window.close_requested.emit()  # Removes the window
+			window.prevent_data_erasure = true  # We don't want to delete data.
+			window.close_requested.emit()  # Removes the window.
 			continue
 	for window: String in _layout.windows.keys():
 		var panel := find_child(window, false)
-		# Only those windows get created which were not previously created
+		# Only those windows get created which were not previously created.
 		if panel:
 			_convert_to_window(panel)
 	_layout_dirty = true
@@ -265,7 +264,7 @@ func set_layout(value: DockableLayout) -> void:
 func set_use_hidden_tabs_for_min_size(value: bool) -> void:
 	_use_hidden_tabs_for_min_size = value
 	for i in range(1, _panel_container.get_child_count()):
-		var panel = _panel_container.get_child(i)
+		var panel := _panel_container.get_child(i) as DockablePanel
 		panel.use_hidden_tabs_for_min_size = value
 
 

--- a/addons/dockable_container/dockable_panel.gd
+++ b/addons/dockable_container/dockable_panel.gd
@@ -40,6 +40,8 @@ func _exit_tree() -> void:
 	active_tab_rearranged.disconnect(_on_tab_changed)
 	tab_selected.disconnect(_on_tab_selected)
 	tab_changed.disconnect(_on_tab_changed)
+	if is_instance_valid(get_popup()):
+		get_popup().queue_free()
 
 
 func track_nodes(nodes: Array[Control], new_leaf: DockableLayoutPanel) -> void:

--- a/addons/dockable_container/floating_window.gd
+++ b/addons/dockable_container/floating_window.gd
@@ -21,7 +21,12 @@ func _init(content: Control, data := {}) -> void:
 
 func _ready() -> void:
 	set_deferred(&"size", Vector2(300, 300))
-	position = DisplayServer.window_get_size() / 2 - size / 2
+	await get_tree().process_frame
+	await get_tree().process_frame
+	if get_tree().current_scene.get_window().gui_embed_subwindows:
+		position = DisplayServer.window_get_size() / 2 - size / 2
+	else:
+		position = DisplayServer.screen_get_usable_rect().size / 2 - size / 2
 
 
 func _input(event: InputEvent) -> void:
@@ -42,7 +47,9 @@ func _deserialize(data: Dictionary) -> void:
 	add_child(window_content)
 	size_changed.connect(window_size_changed)
 	if "position" in data:
-		set_position(data["position"])
+		await get_tree().process_frame
+		await get_tree().process_frame
+		position = data["position"]
 	if "size" in data:
 		set_deferred(&"size", data["size"])
 	_is_initialized = true

--- a/addons/dockable_container/floating_window.gd
+++ b/addons/dockable_container/floating_window.gd
@@ -16,6 +16,7 @@ func _init(content: Control, data := {}) -> void:
 	min_size = window_content.get_minimum_size()
 	unresizable = false
 	wrap_controls = true
+	always_on_top = true
 	ready.connect(_deserialize.bind(data))
 
 

--- a/addons/dockable_container/floating_window.gd
+++ b/addons/dockable_container/floating_window.gd
@@ -1,0 +1,65 @@
+class_name FloatingWindow
+extends Window
+
+signal data_changed
+
+var window_content: Control
+var _is_initialized := false
+var prevent_data_erasure := false
+
+
+func _init(content: Control, data := {}) -> void:
+	window_content = content
+	title = window_content.name
+	name = window_content.name
+	min_size = window_content.get_minimum_size()
+	unresizable = false
+	wrap_controls = true
+	ready.connect(_deserialize.bind(data))
+
+
+func _ready() -> void:
+	set_deferred(&"size", Vector2(300, 300))
+	#set_deferred(&"position", DisplayServer.window_get_size() / 2 - size / 2)
+	position = DisplayServer.window_get_size() / 2 - size / 2
+
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventMouse:
+		if not window_content.get_rect().has_point(event.position) and _is_initialized:
+			data_changed.emit(name, serialize())
+
+
+func serialize() -> Dictionary:
+	return {"size": size, "position": position}
+
+
+func _deserialize(data: Dictionary) -> void:
+	window_content.get_parent().remove_child(window_content)
+	window_content.visible = true
+	window_content.global_position = Vector2.ZERO
+	add_child(window_content)
+	size_changed.connect(window_size_changed)
+	if not data.is_empty():
+		if "position" in data:
+			set_position(data["position"])
+		if "size" in data:
+			set_deferred(&"size", data["size"])
+	_is_initialized = true
+
+
+func window_size_changed() -> void:
+	window_content.size = size
+	window_content.position = Vector2.ZERO
+	if _is_initialized:
+		data_changed.emit(name, serialize())
+
+
+func destroy() -> void:
+	size_changed.disconnect(window_size_changed)
+	queue_free()
+
+
+func _exit_tree() -> void:
+	if _is_initialized and !prevent_data_erasure:
+		data_changed.emit(name, {})

--- a/addons/dockable_container/floating_window.gd
+++ b/addons/dockable_container/floating_window.gd
@@ -4,8 +4,8 @@ extends Window
 signal data_changed
 
 var window_content: Control
-var _is_initialized := false
 var prevent_data_erasure := false
+var _is_initialized := false
 
 
 func _init(content: Control, data := {}) -> void:

--- a/addons/dockable_container/floating_window.gd
+++ b/addons/dockable_container/floating_window.gd
@@ -1,6 +1,7 @@
 class_name FloatingWindow
 extends Window
 
+## Emitted when the window's position or size changes, or when it's closed.
 signal data_changed
 
 var window_content: Control
@@ -20,12 +21,12 @@ func _init(content: Control, data := {}) -> void:
 
 func _ready() -> void:
 	set_deferred(&"size", Vector2(300, 300))
-	#set_deferred(&"position", DisplayServer.window_get_size() / 2 - size / 2)
 	position = DisplayServer.window_get_size() / 2 - size / 2
 
 
 func _input(event: InputEvent) -> void:
 	if event is InputEventMouse:
+		# Emit `data_changed` when the window is being moved.
 		if not window_content.get_rect().has_point(event.position) and _is_initialized:
 			data_changed.emit(name, serialize())
 
@@ -40,11 +41,10 @@ func _deserialize(data: Dictionary) -> void:
 	window_content.global_position = Vector2.ZERO
 	add_child(window_content)
 	size_changed.connect(window_size_changed)
-	if not data.is_empty():
-		if "position" in data:
-			set_position(data["position"])
-		if "size" in data:
-			set_deferred(&"size", data["size"])
+	if "position" in data:
+		set_position(data["position"])
+	if "size" in data:
+		set_deferred(&"size", data["size"])
 	_is_initialized = true
 
 

--- a/addons/dockable_container/layout.gd
+++ b/addons/dockable_container/layout.gd
@@ -23,10 +23,19 @@ enum { MARGIN_LEFT, MARGIN_RIGHT, MARGIN_TOP, MARGIN_BOTTOM, MARGIN_CENTER }
 		if value != _hidden_tabs:
 			_hidden_tabs = value
 			changed.emit()
+## A [Dictionary] of [StringName] and [Dictionary], containing data such as position and size.
+@export var windows := {}:
+	get:
+		return _windows
+	set(value):
+		if value != _windows:
+			_windows = value
+			changed.emit()
 
 var _changed_signal_queued := false
 var _first_leaf: DockableLayoutPanel
 var _hidden_tabs: Dictionary
+var _windows: Dictionary
 var _leaf_by_node_name: Dictionary
 var _root: DockableLayoutNode = DockableLayoutPanel.new()
 
@@ -164,6 +173,15 @@ func set_tab_hidden(name: String, hidden: bool) -> void:
 	else:
 		_hidden_tabs.erase(name)
 	_on_root_changed()
+
+
+func save_window_properties(window_name: StringName, data: Dictionary) -> void:
+	var new_windows = windows.duplicate(true)
+	if data.is_empty():
+		new_windows.erase(window_name)
+	else:
+		new_windows[window_name] = data
+	windows = new_windows
 
 
 func is_tab_hidden(name: String) -> bool:

--- a/addons/dockable_container/samples/TestScene.tscn
+++ b/addons/dockable_container/samples/TestScene.tscn
@@ -31,6 +31,8 @@ resource_name = "Layout"
 script = ExtResource("2")
 root = SubResource("Resource_hl8y1")
 hidden_tabs = {}
+windows = {}
+save_on_change = false
 
 [sub_resource type="Resource" id="Resource_ntwfj"]
 resource_name = "Tabs"
@@ -71,6 +73,8 @@ resource_name = "Layout"
 script = ExtResource("2")
 root = SubResource("Resource_jhibs")
 hidden_tabs = {}
+windows = {}
+save_on_change = false
 
 [node name="SampleScene" type="VBoxContainer"]
 anchors_preset = 15


### PR DESCRIPTION
Implements #4, a continuation of #18 for Godot 4. Many thanks to @Variable-ind for starting the work!

![Peek 2024-10-09 13-53](https://github.com/user-attachments/assets/bea602b5-c2b2-4426-9599-0e1136bbff2e)

Tab containers now have settings with a "Make Floating" option. This is what makes panels into windows. To make windows into panels again, simply close the window. If the original tab container of the panel still exists when the window closes (meaning that it has more tabs and it did not get freed), the panel returns to that tab container. If it doesn't exist, it is being added to the first available tab container.

Based on my testing, it works well with embed subwindows both true and false. Windows and their data (position and size) are being stored in the layout, and thus are being remembered between sessions.

Probably the biggest issue with this is that child controls are being reparented to window nodes. Given how windows work in Godot, I don't think soft parenting is possible, especially now that we can have separate windows. But of course I may be wrong, so ideas are welcome!