### PR TITLE
Add EditorRun to drag_n_drop_panel.gd

### DIFF
--- a/addons/dockable_container/drag_n_drop_panel.gd
+++ b/addons/dockable_container/drag_n_drop_panel.gd
@@ -1,5 +1,6 @@
 tool
 extends Control
+extends EditorRun
 
 const DRAW_NOTHING = -1
 const DRAW_CENTERED = -2


### PR DESCRIPTION
I added: extend EditorRun ( class EditorRun) from file Godot/editor/editor_run.h 
My idea is to be able to change the position of the PlayTest buttons just like your extension allows you to move the Inspector, among other things.
Thank you very much for that. 
I might try to check it out on my Godot 3.6 fork on Friday.
 Let me know if you check it out before then.
I'm adding this again because I forgot to change the branch to 3 and when I did, all the commits from Others were included.  
I'm still learning Github.
Have a nice Sunday.